### PR TITLE
change the implementation of the Yoshida fourth-order symplectic integrator.

### DIFF
--- a/standards/integrator.hpp
+++ b/standards/integrator.hpp
@@ -124,39 +124,37 @@ private:
 class yoshida_symplectic_4 {
 public:
   static std::string name() { return "4th-order Yoshida symplectic method"; }
-  yoshida_symplectic_4(std::size_t dim) : dim_(dim), k1_(dim), k2_(dim), k3_(dim), k4_(dim){}
+  yoshida_symplectic_4(std::size_t dim) : dim_(dim), k1_(dim), k2_(dim), k3_(dim){}
   template<class F>
   void step(double t, double h, std::vector<double>& y, F const& f) const {
-    const std::size_t dim2 = dim_ / 2;
+    const int  dim2 = dim_ / 2;
     const double h2 = h * h;
-    double b1 = 1.0/(4.0 - 2.0*std::pow(2.0,1.0/3.0));  
-    double b2 = (1.0 - std::pow(2.0,1.0/3.0))/(4.0 - 2.0*std::pow(2.0,1.0/3.0));  
-    double c1 = 1.0 / (2.0 - std::pow(2.0,1.0/3.0));
-    double c2 = 1.0 / (1.0 - std::pow(2.0,2.0/3.0));
+    double c1 = 1.0/(4.0 - std::pow(2.0,4.0/3.0));  
+    double c2 = (1.0 - std::pow(2.0,1.0/3.0))/(4.0 - std::pow(2.0,4.0/3.0));
+    double b1 = 1.0 / (2.0 - std::pow(2.0,1.0/3.0));
+    double b2 = 1.0 / (1.0 - std::pow(2.0,2.0/3.0));
+    for (int i = 0; i < dim2; ++i) y[i] = y[i] +  h * c1 * y[i + dim2];
     f(t, y, k1_);
-    for (std::size_t i = 0; i < dim2; ++i){
-      y[i] = y[i] +  h * c1 * k1_[i] + h2 * c1 * b1 * k1_[i+dim2];
+    for (int i = 0; i < dim2; ++i){
       y[i + dim2] = y[i + dim2] + h * b1 * k1_[i + dim2];
+      y[i] = y[i] +  h * c2 * y[i + dim2];
     }
     f(t, y, k2_);
-    for (std::size_t i = 0; i < dim2; ++i){
-      y[i] = y[i] +  h * c2 * k2_[i] + h2 * c2 * b2 * k2_[i+dim2];
+    for (int i = 0; i < dim2; ++i){
       y[i + dim2] = y[i + dim2] + h * b2 * k2_[i + dim2];
+      y[i] = y[i] +  h * c2 * y[i + dim2];
     }
     f(t, y, k3_);
-    for (std::size_t i = 0; i < dim2; ++i){
-      y[i] = y[i] +  h * c1 * k3_[i] + h2 * c1 * b2 * k3_[i+dim2];
-      y[i + dim2] = y[i + dim2] + h * b2 * k3_[i + dim2];
+    for (int i = 0; i < dim2; ++i){
+      y[i + dim2] = y[i + dim2] + h * b1 * k3_[i + dim2];
+      y[i] = y[i] +  h * c1 * y[i + dim2];
     }
-    f(t, y, k4_);
-    for (std::size_t i = dim2; i < dim_; ++i) y[i] = y[i] + h * b1 * k4_[i];
   }
 private:
   std::size_t dim_;
   mutable std::vector<double> k1_;
   mutable std::vector<double> k2_;
   mutable std::vector<double> k3_;
-  mutable std::vector<double> k4_;
 };
 
 

--- a/standards/integrator.hpp
+++ b/standards/integrator.hpp
@@ -128,7 +128,6 @@ public:
   template<class F>
   void step(double t, double h, std::vector<double>& y, F const& f) const {
     const int  dim2 = dim_ / 2;
-    const double h2 = h * h;
     double c1 = 1.0/(4.0 - std::pow(2.0,4.0/3.0));  
     double c2 = (1.0 - std::pow(2.0,1.0/3.0))/(4.0 - std::pow(2.0,4.0/3.0));
     double b1 = 1.0 / (2.0 - std::pow(2.0,1.0/3.0));


### PR DESCRIPTION
I change the implementation of the Yoshida fourth-order symplectic integrator according with the original paper.
The previous algorithm is one of the four deformations of fourth-order symplectic integrators.

We can derive four types of the fourth-order symplectic integrators depending on the pair of coefficients and order of operators.

Reference:
- H. Yoshida, “Construction of higher order symplectic integrators”, Physics Letters A 150, 262 (1990).
- E. Forest and R. D. Ruth, “Fourth-order symplectic integration”, Physica D: Nonlinear Phenomena 43, 105 (1990).